### PR TITLE
add autoincrement primary key `id`

### DIFF
--- a/schema/v007.sql
+++ b/schema/v007.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `app_center`.`t_app_scope` ADD COLUMN `id` int NOT NULL AUTO_INCREMENT FIRST, ADD PRIMARY KEY (`id`);
+ALTER TABLE `app_center`.`t_app_user_relation` ADD COLUMN `id` int NOT NULL AUTO_INCREMENT FIRST, ADD PRIMARY KEY (`id`);


### PR DESCRIPTION
To meet the requirement that tables in the database must have primary keys under database architectures such as MySQL Mgr，add an auto_increment primary key `id` to `t_app_scope` and `t_app_user_relation`